### PR TITLE
Refactor Ninja build files

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -5,47 +5,12 @@ warn = -Weverything $
     -Wno-declaration-after-statement $
     -Wno-poison-system-directories $
     -Wno-switch-default $
-    -Wno-unsafe-buffer-usage $
+    -Wno-unsafe-buffer-usage
 
 dev = -Og
 lto = $dev -flto
 san = -fsanitize=address,integer,undefined
 
-rule compile
-    command = $cc -g -Werror $warn -fcolor-diagnostics $flags -MD -MF $out.d $
-                  -c $in -o $out
-    depfile = $out.d
-    deps    = gcc
-
-rule link
-    command = $cc $in $flags -o $out
-
-rule test
-    command = ./$in $args > $out
-
-build out/dev/vorth.o:       compile vorth.c
-    flags = $dev
-build out/dev/vorth_test.o:  compile vorth_test.c
-    flags = $dev
-build out/dev/vorth_test:    link out/dev/vorth_test.o out/dev/vorth.o
-    flags = $dev
-build out/dev/vorth_test.ok: test out/dev/vorth_test
-    flags = $dev
-
-build out/lto/vorth.o:       compile vorth.c
-    flags = $lto
-build out/lto/vorth_test.o:  compile vorth_test.c
-    flags = $lto
-build out/lto/vorth_test:    link out/lto/vorth_test.o out/lto/vorth.o
-    flags = $lto
-build out/lto/vorth_test.ok: test out/lto/vorth_test
-    flags = $lto
-
-build out/san/vorth.o:       compile vorth.c
-    flags = $san
-build out/san/vorth_test.o:  compile vorth_test.c
-    flags = $san
-build out/san/vorth_test:    link out/san/vorth_test.o out/san/vorth.o
-    flags = $san
-build out/san/vorth_test.ok: test out/san/vorth_test
-    flags = $san
+subninja build/dev
+subninja build/lto
+subninja build/san

--- a/build/dev
+++ b/build/dev
@@ -1,0 +1,3 @@
+mode  = dev
+flags = $dev
+subninja build/rules

--- a/build/lto
+++ b/build/lto
@@ -1,0 +1,3 @@
+mode  = lto
+flags = $lto
+subninja build/rules

--- a/build/rules
+++ b/build/rules
@@ -1,0 +1,24 @@
+# Common build rules. Expects $mode and $flags.
+
+outdir = $builddir/$mode
+
+rule compile
+    command = $cc -g -Werror $warn -fcolor-diagnostics $flags -MD -MF $out.d $
+                  -c $in -o $out
+    depfile = $out.d
+    deps    = gcc
+
+rule link
+    command = $cc $in $flags -o $out
+
+rule test
+    command = ./$in $args > $out
+
+build $outdir/vorth.o:       compile vorth.c
+    flags = $flags
+build $outdir/vorth_test.o:  compile vorth_test.c
+    flags = $flags
+build $outdir/vorth_test:    link $outdir/vorth_test.o $outdir/vorth.o
+    flags = $flags
+build $outdir/vorth_test.ok: test $outdir/vorth_test
+    flags = $flags

--- a/build/san
+++ b/build/san
@@ -1,0 +1,3 @@
+mode  = san
+flags = $san
+subninja build/rules


### PR DESCRIPTION
## Summary
- split build rules into `build/rules`
- create mode specific build configs in `build/dev`, `build/lto`, and `build/san`
- simplify top-level `build.ninja` to include each mode

## Testing
- `ninja -t targets | head`
- `ninja` *(fails: could not load LLVMgold.so during lto build)*

------
https://chatgpt.com/codex/tasks/task_e_68574fe5f27083269e2eb1d53fc7225e