### PR TITLE
Expose vector width and new pop helpers

### DIFF
--- a/vorth.c
+++ b/vorth.c
@@ -1,7 +1,5 @@
 #include "vorth.h"
 
-#define V 8
-
 typedef _Float16 F16 __attribute__((vector_size(sizeof(_Float16) * V)));
 typedef float    F32 __attribute__((vector_size(sizeof(float) * V)));
 
@@ -98,5 +96,23 @@ void* vorth_mad_f32(void* sp) {
     F32 b = *--stack;
     F32 a = *--stack;
     *stack++ = a * b + c;
+    return stack;
+}
+
+void* vorth_pop_f16(void* sp, _Float16 out[V]) {
+    F16* stack = sp;
+    F16 x = *--stack;
+    for (int i = 0; i < V; i++) {
+        out[i] = x[i];
+    }
+    return stack;
+}
+
+void* vorth_pop_f32(void* sp, float out[V]) {
+    F32* stack = sp;
+    F32 x = *--stack;
+    for (int i = 0; i < V; i++) {
+        out[i] = x[i];
+    }
     return stack;
 }

--- a/vorth.h
+++ b/vorth.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define V 8
+
 // vorth is a SIMT-style vectorized Forth-style language.  Its priorities:
 //   - correctness
 //   - efficient memory access
@@ -27,3 +29,6 @@ void* vorth_sub_f32(void*);
 void* vorth_mul_f32(void*);
 void* vorth_div_f32(void*);
 void* vorth_mad_f32(void*);
+
+void* vorth_pop_f16(void*, _Float16[V]);
+void* vorth_pop_f32(void*, float[V]);

--- a/vorth_test.c
+++ b/vorth_test.c
@@ -1,7 +1,6 @@
 #include "vorth.h"
 #include <assert.h>
 
-#define V 8
 
 static inline int equiv_f16(_Float16 x, _Float16 y) {
     return (x <= y && y <= x) || (x != x && y != y);
@@ -18,7 +17,8 @@ static void test_f16(void) {
     sp = vorth_imm_f16(sp, 1);
     sp = vorth_imm_f16(sp, 2);
     sp = vorth_add_f16(sp);
-    _Float16* res = (_Float16*)sp - V;
+    _Float16 res[V];
+    sp = vorth_pop_f16(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f16(res[i], 3));
     }
@@ -27,7 +27,7 @@ static void test_f16(void) {
     sp = vorth_imm_f16(sp, 5);
     sp = vorth_imm_f16(sp, 3);
     sp = vorth_sub_f16(sp);
-    res = (_Float16*)sp - V;
+    sp = vorth_pop_f16(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f16(res[i], 2));
     }
@@ -36,7 +36,7 @@ static void test_f16(void) {
     sp = vorth_imm_f16(sp, 2);
     sp = vorth_imm_f16(sp, 3);
     sp = vorth_mul_f16(sp);
-    res = (_Float16*)sp - V;
+    sp = vorth_pop_f16(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f16(res[i], 6));
     }
@@ -45,7 +45,7 @@ static void test_f16(void) {
     sp = vorth_imm_f16(sp, 6);
     sp = vorth_imm_f16(sp, 2);
     sp = vorth_div_f16(sp);
-    res = (_Float16*)sp - V;
+    sp = vorth_pop_f16(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f16(res[i], 3));
     }
@@ -55,7 +55,7 @@ static void test_f16(void) {
     sp = vorth_imm_f16(sp, 3);
     sp = vorth_imm_f16(sp, 4);
     sp = vorth_mad_f16(sp);
-    res = (_Float16*)sp - V;
+    sp = vorth_pop_f16(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f16(res[i], 10));
     }
@@ -68,7 +68,8 @@ static void test_f32(void) {
     sp = vorth_imm_f32(sp, 1);
     sp = vorth_imm_f32(sp, 2);
     sp = vorth_add_f32(sp);
-    float* res = (float*)sp - V;
+    float res[V];
+    sp = vorth_pop_f32(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f32(res[i], 3));
     }
@@ -77,7 +78,7 @@ static void test_f32(void) {
     sp = vorth_imm_f32(sp, 5);
     sp = vorth_imm_f32(sp, 3);
     sp = vorth_sub_f32(sp);
-    res = (float*)sp - V;
+    sp = vorth_pop_f32(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f32(res[i], 2));
     }
@@ -86,7 +87,7 @@ static void test_f32(void) {
     sp = vorth_imm_f32(sp, 2);
     sp = vorth_imm_f32(sp, 3);
     sp = vorth_mul_f32(sp);
-    res = (float*)sp - V;
+    sp = vorth_pop_f32(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f32(res[i], 6));
     }
@@ -95,7 +96,7 @@ static void test_f32(void) {
     sp = vorth_imm_f32(sp, 6);
     sp = vorth_imm_f32(sp, 2);
     sp = vorth_div_f32(sp);
-    res = (float*)sp - V;
+    sp = vorth_pop_f32(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f32(res[i], 3));
     }
@@ -105,7 +106,7 @@ static void test_f32(void) {
     sp = vorth_imm_f32(sp, 3);
     sp = vorth_imm_f32(sp, 4);
     sp = vorth_mad_f32(sp);
-    res = (float*)sp - V;
+    sp = vorth_pop_f32(sp, res);
     for (int i = 0; i < V; i++) {
         assert(equiv_f32(res[i], 10));
     }


### PR DESCRIPTION
## Summary
- expose the vector width `V` in the public header
- add `vorth_pop_f16` and `vorth_pop_f32` stack helpers
- remove local `V` constants from tests and use new pop helpers

## Testing
- `ninja -f build.ninja`

------
https://chatgpt.com/codex/tasks/task_e_685760ed53308326ba4cf953c9f9246d