### PR TITLE
Align function variable style

### DIFF
--- a/vorth.c
+++ b/vorth.c
@@ -15,32 +15,32 @@ void* vorth_imm_f16(void* sp, _Float16 x) {
 
 void* vorth_add_f16(void* sp) {
     F16* stack = sp;
-    F16 b = *--stack;
-    F16 a = *--stack;
+    F16 const b = *--stack,
+              a = *--stack;
     *stack++ = a + b;
     return stack;
 }
 
 void* vorth_sub_f16(void* sp) {
     F16* stack = sp;
-    F16 b = *--stack;
-    F16 a = *--stack;
+    F16 const b = *--stack,
+              a = *--stack;
     *stack++ = a - b;
     return stack;
 }
 
 void* vorth_mul_f16(void* sp) {
     F16* stack = sp;
-    F16 b = *--stack;
-    F16 a = *--stack;
+    F16 const b = *--stack,
+              a = *--stack;
     *stack++ = a * b;
     return stack;
 }
 
 void* vorth_div_f16(void* sp) {
     F16* stack = sp;
-    F16 b = *--stack;
-    F16 a = *--stack;
+    F16 const b = *--stack,
+              a = *--stack;
     *stack++ = a / b;
     return stack;
 }
@@ -62,41 +62,41 @@ void* vorth_imm_f32(void* sp, float x) {
 
 void* vorth_add_f32(void* sp) {
     F32* stack = sp;
-    F32 b = *--stack;
-    F32 a = *--stack;
+    F32 const b = *--stack,
+              a = *--stack;
     *stack++ = a + b;
     return stack;
 }
 
 void* vorth_sub_f32(void* sp) {
     F32* stack = sp;
-    F32 b = *--stack;
-    F32 a = *--stack;
+    F32 const b = *--stack,
+              a = *--stack;
     *stack++ = a - b;
     return stack;
 }
 
 void* vorth_mul_f32(void* sp) {
     F32* stack = sp;
-    F32 b = *--stack;
-    F32 a = *--stack;
+    F32 const b = *--stack,
+              a = *--stack;
     *stack++ = a * b;
     return stack;
 }
 
 void* vorth_div_f32(void* sp) {
     F32* stack = sp;
-    F32 b = *--stack;
-    F32 a = *--stack;
+    F32 const b = *--stack,
+              a = *--stack;
     *stack++ = a / b;
     return stack;
 }
 
 void* vorth_mad_f32(void* sp) {
     F32* stack = sp;
-    F32 c = *--stack;
-    F32 b = *--stack;
-    F32 a = *--stack;
+    F32 const c = *--stack,
+              b = *--stack,
+              a = *--stack;
     *stack++ = a * b + c;
     return stack;
 }


### PR DESCRIPTION
## Summary
- update function definitions in `vorth.c` to match the formatting used by `vorth_mad_f16`

## Testing
- `ninja out/dev/vorth_test.ok`
- `ninja out/lto/vorth_test.ok`
- `ninja out/san/vorth_test.ok`


------
https://chatgpt.com/codex/tasks/task_e_68576145d12c83268d5e84809b414a4e