### PR TITLE
Add SIMD integer operations

### DIFF
--- a/vorth.c
+++ b/vorth.c
@@ -3,7 +3,80 @@
 typedef _Float16 F16 __attribute__((vector_size(sizeof(_Float16) * V)));
 typedef float    F32 __attribute__((vector_size(sizeof(float) * V)));
 
+typedef signed char       S8  __attribute__((vector_size(sizeof(signed char) * V)));
+typedef unsigned char     U8  __attribute__((vector_size(sizeof(unsigned char) * V)));
+typedef short             S16 __attribute__((vector_size(sizeof(short) * V)));
+typedef unsigned short    U16 __attribute__((vector_size(sizeof(unsigned short) * V)));
+typedef int               S32 __attribute__((vector_size(sizeof(int) * V)));
+typedef unsigned int      U32 __attribute__((vector_size(sizeof(unsigned int) * V)));
+
+typedef U8  I8;
+typedef U16 I16;
+typedef U32 I32;
+
 #define splat(T, x) ((T){0} + 1) * (x)
+
+#define DEFINE_IMM(T, suf, ctype)                 \
+    void* vorth_imm_##suf(void* sp, ctype x) {    \
+        T* stack = sp;                            \
+        *stack++ = splat(T, x);                   \
+        return stack;                             \
+    }
+
+#define DEFINE_ARITH(T, suf)                      \
+    void* vorth_add_##suf(void* sp) {             \
+        T* stack = sp;                            \
+        T const b = *--stack, a = *--stack;       \
+        *stack++ = a + b;                         \
+        return stack;                             \
+    }                                             \
+    void* vorth_sub_##suf(void* sp) {             \
+        T* stack = sp;                            \
+        T const b = *--stack, a = *--stack;       \
+        *stack++ = a - b;                         \
+        return stack;                             \
+    }                                             \
+    void* vorth_mul_##suf(void* sp) {             \
+        T* stack = sp;                            \
+        T const b = *--stack, a = *--stack;       \
+        *stack++ = a * b;                         \
+        return stack;                             \
+    }
+
+#define DEFINE_POP(T, suf, ctype)                 \
+    void* vorth_pop_##suf(void* sp, ctype out[V]) {\
+        T* stack = sp;                            \
+        T x = *--stack;                           \
+        __builtin_memcpy(out, &x, sizeof x);      \
+        return stack;                             \
+    }
+
+
+#define DEFINE_BITWISE(T, suf)                    \
+    void* vorth_and_##suf(void* sp) {             \
+        T* stack = sp;                            \
+        T const b = *--stack, a = *--stack;       \
+        *stack++ = a & b;                         \
+        return stack;                             \
+    }                                             \
+    void* vorth_or_##suf(void* sp) {              \
+        T* stack = sp;                            \
+        T const b = *--stack, a = *--stack;       \
+        *stack++ = a | b;                         \
+        return stack;                             \
+    }                                             \
+    void* vorth_xor_##suf(void* sp) {             \
+        T* stack = sp;                            \
+        T const b = *--stack, a = *--stack;       \
+        *stack++ = a ^ b;                         \
+        return stack;                             \
+    }                                             \
+    void* vorth_not_##suf(void* sp) {             \
+        T* stack = sp;                            \
+        T const a = *--stack;                     \
+        *stack++ = ~a;                            \
+        return stack;                             \
+    }
 
 void* vorth_imm_f16(void* sp, _Float16 x) {
     F16* stack = sp;
@@ -112,3 +185,29 @@ void* vorth_pop_f32(void* sp, float out[V]) {
     __builtin_memcpy(out, &x, sizeof x);
     return stack;
 }
+
+// Signed integer immediates and pop
+DEFINE_IMM(S8,  s8,  signed char)
+DEFINE_POP(S8,  s8,  signed char)
+DEFINE_IMM(S16, s16, short)
+DEFINE_POP(S16, s16, short)
+DEFINE_IMM(S32, s32, int)
+DEFINE_POP(S32, s32, int)
+
+// Unsigned integer immediates and pop
+DEFINE_IMM(U8,  u8,  unsigned char)
+DEFINE_POP(U8,  u8,  unsigned char)
+DEFINE_IMM(U16, u16, unsigned short)
+DEFINE_POP(U16, u16, unsigned short)
+DEFINE_IMM(U32, u32, unsigned int)
+DEFINE_POP(U32, u32, unsigned int)
+
+// Integer arithmetic
+DEFINE_ARITH(I8,  i8)
+DEFINE_ARITH(I16, i16)
+DEFINE_ARITH(I32, i32)
+
+// Bitwise operations
+DEFINE_BITWISE(I8,  i8)
+DEFINE_BITWISE(I16, i16)
+DEFINE_BITWISE(I32, i32)

--- a/vorth.h
+++ b/vorth.h
@@ -32,3 +32,52 @@ void* vorth_mad_f32(void*);
 
 void* vorth_pop_f16(void*, _Float16[V]);
 void* vorth_pop_f32(void*, float[V]);
+
+// Signed integer operations
+void* vorth_imm_s8(void*, signed char);
+void* vorth_pop_s8(void*, signed char[V]);
+
+void* vorth_imm_s16(void*, short);
+void* vorth_pop_s16(void*, short[V]);
+
+void* vorth_imm_s32(void*, int);
+void* vorth_pop_s32(void*, int[V]);
+
+// Unsigned integer operations
+void* vorth_imm_u8(void*, unsigned char);
+void* vorth_pop_u8(void*, unsigned char[V]);
+
+void* vorth_imm_u16(void*, unsigned short);
+void* vorth_pop_u16(void*, unsigned short[V]);
+
+void* vorth_imm_u32(void*, unsigned int);
+void* vorth_pop_u32(void*, unsigned int[V]);
+
+// Integer arithmetic (signedness agnostic)
+void* vorth_add_i8(void*);
+void* vorth_sub_i8(void*);
+void* vorth_mul_i8(void*);
+
+void* vorth_add_i16(void*);
+void* vorth_sub_i16(void*);
+void* vorth_mul_i16(void*);
+
+void* vorth_add_i32(void*);
+void* vorth_sub_i32(void*);
+void* vorth_mul_i32(void*);
+
+// Bitwise operations (signedness agnostic)
+void* vorth_and_i8(void*);
+void* vorth_or_i8(void*);
+void* vorth_xor_i8(void*);
+void* vorth_not_i8(void*);
+
+void* vorth_and_i16(void*);
+void* vorth_or_i16(void*);
+void* vorth_xor_i16(void*);
+void* vorth_not_i16(void*);
+
+void* vorth_and_i32(void*);
+void* vorth_or_i32(void*);
+void* vorth_xor_i32(void*);
+void* vorth_not_i32(void*);

--- a/vorth_test.c
+++ b/vorth_test.c
@@ -10,6 +10,28 @@ static inline int equiv_f32(float x, float y) {
     return (x <= y && y <= x) || (x != x && y != y);
 }
 
+static void test_s32(void) {
+    int stack[8 * V] __attribute__((aligned(sizeof(int) * V)));
+    void* sp = stack;
+
+    sp = vorth_imm_s32(sp, 1);
+    sp = vorth_imm_s32(sp, 2);
+    sp = vorth_add_i32(sp);
+    int res[V];
+    sp = vorth_pop_s32(sp, res);
+    for (int i = 0; i < V; i++) {
+        assert(res[i] == 3);
+    }
+
+    sp = stack;
+    sp = vorth_imm_s32(sp, 0);
+    sp = vorth_not_i32(sp);
+    sp = vorth_pop_s32(sp, res);
+    for (int i = 0; i < V; i++) {
+        assert(res[i] == ~0);
+    }
+}
+
 static void test_f16(void) {
     _Float16 stack[8 * V] __attribute__((aligned(sizeof(_Float16) * V)));
     void* sp = stack;
@@ -113,6 +135,7 @@ static void test_f32(void) {
 }
 
 int main(void) {
+    test_s32();
     test_f16();
     test_f32();
     return 0;


### PR DESCRIPTION
## Summary
- extend vorth API with SIMD integer and bitwise functions
- implement new operations using vector intrinsics
- test basic s32 math and bitwise support

## Testing
- `ninja -f build.ninja -C .`

------
https://chatgpt.com/codex/tasks/task_e_685765d71ffc8326af8662551f26b2a7