### PR TITLE
Align macros and rename vector types

### DIFF
--- a/vorth.c
+++ b/vorth.c
@@ -16,35 +16,35 @@ typedef u32 i32;
 
 #define splat(T, x) ((T){0} + 1) * (x)
 
-#define DEFINE_IMM(T, suf, ctype)                  \
-    void* vorth_imm_##suf(void* sp, ctype x) {     \
+#define DEFINE_IMM(T, ctype)                       \
+    void* vorth_imm_##T(void* sp, ctype x) {       \
         T* stack = sp;                             \
         *stack++ = splat(T, x);                    \
         return stack;                              \
     }
 
-#define DEFINE_ARITH(T, suf)                       \
-    void* vorth_add_##suf(void* sp) {              \
+#define DEFINE_ARITH(T)                            \
+    void* vorth_add_##T(void* sp) {                \
         T* stack = sp;                             \
         T const b = *--stack, a = *--stack;        \
         *stack++ = a + b;                          \
         return stack;                              \
     }                                              \
-    void* vorth_sub_##suf(void* sp) {              \
+    void* vorth_sub_##T(void* sp) {                \
         T* stack = sp;                             \
         T const b = *--stack, a = *--stack;        \
         *stack++ = a - b;                          \
         return stack;                              \
     }                                              \
-    void* vorth_mul_##suf(void* sp) {              \
+    void* vorth_mul_##T(void* sp) {                \
         T* stack = sp;                             \
         T const b = *--stack, a = *--stack;        \
         *stack++ = a * b;                          \
         return stack;                              \
     }
 
-#define DEFINE_POP(T, suf, ctype)                  \
-    void* vorth_pop_##suf(void* sp, ctype out[V]) { \
+#define DEFINE_POP(T, ctype)                       \
+    void* vorth_pop_##T(void* sp, ctype out[V]) {  \
         T* stack = sp;                             \
         T const x = *--stack;                      \
         __builtin_memcpy(out, &x, sizeof x);       \
@@ -52,26 +52,26 @@ typedef u32 i32;
     }
 
 
-#define DEFINE_BITWISE(T, suf)                      \
-    void* vorth_and_##suf(void* sp) {               \
+#define DEFINE_BITWISE(T)                           \
+    void* vorth_and_##T(void* sp) {                 \
         T* stack = sp;                              \
         T const b = *--stack, a = *--stack;         \
         *stack++ = a & b;                           \
         return stack;                               \
     }                                               \
-    void* vorth_or_##suf(void* sp) {                \
+    void* vorth_or_##T(void* sp) {                  \
         T* stack = sp;                              \
         T const b = *--stack, a = *--stack;         \
         *stack++ = a | b;                           \
         return stack;                               \
     }                                               \
-    void* vorth_xor_##suf(void* sp) {               \
+    void* vorth_xor_##T(void* sp) {                 \
         T* stack = sp;                              \
         T const b = *--stack, a = *--stack;         \
         *stack++ = a ^ b;                           \
         return stack;                               \
     }                                               \
-    void* vorth_not_##suf(void* sp) {               \
+    void* vorth_not_##T(void* sp) {                 \
         T* stack = sp;                              \
         T const a = *--stack;                       \
         *stack++ = ~a;                              \
@@ -79,16 +79,16 @@ typedef u32 i32;
     }
 
 
-#define DEFINE_DIV(T, suf)                          \
-    void* vorth_div_##suf(void* sp) {              \
+#define DEFINE_DIV(T)                              \
+    void* vorth_div_##T(void* sp) {                \
         T* stack = sp;                             \
         T const b = *--stack, a = *--stack;        \
         *stack++ = a / b;                          \
         return stack;                              \
     }
 
-#define DEFINE_MAD(T, suf)                          \
-    void* vorth_mad_##suf(void* sp) {              \
+#define DEFINE_MAD(T)                               \
+    void* vorth_mad_##T(void* sp) {                \
         T* stack = sp;                             \
         T const c = *--stack,                      \
                 b = *--stack,                      \
@@ -97,36 +97,36 @@ typedef u32 i32;
         return stack;                              \
     }
 
-DEFINE_IMM(f16, f16, _Float16)
-DEFINE_POP(f16, f16, _Float16)
-DEFINE_ARITH(f16, f16)
-DEFINE_DIV(f16, f16)
-DEFINE_MAD(f16, f16)
+DEFINE_IMM(f16, _Float16)
+DEFINE_POP(f16, _Float16)
+DEFINE_ARITH(f16)
+DEFINE_DIV(f16)
+DEFINE_MAD(f16)
 
-DEFINE_IMM(f32, f32, float)
-DEFINE_POP(f32, f32, float)
-DEFINE_ARITH(f32, f32)
-DEFINE_DIV(f32, f32)
-DEFINE_MAD(f32, f32)
+DEFINE_IMM(f32, float)
+DEFINE_POP(f32, float)
+DEFINE_ARITH(f32)
+DEFINE_DIV(f32)
+DEFINE_MAD(f32)
 
-DEFINE_IMM(s8,  s8,  signed char)
-DEFINE_POP(s8,  s8,  signed char)
-DEFINE_IMM(s16, s16, short)
-DEFINE_POP(s16, s16, short)
-DEFINE_IMM(s32, s32, int)
-DEFINE_POP(s32, s32, int)
+DEFINE_IMM(s8,  signed char)
+DEFINE_POP(s8,  signed char)
+DEFINE_IMM(s16, short)
+DEFINE_POP(s16, short)
+DEFINE_IMM(s32, int)
+DEFINE_POP(s32, int)
 
-DEFINE_IMM(u8,  u8,  unsigned char)
-DEFINE_POP(u8,  u8,  unsigned char)
-DEFINE_IMM(u16, u16, unsigned short)
-DEFINE_POP(u16, u16, unsigned short)
-DEFINE_IMM(u32, u32, unsigned int)
-DEFINE_POP(u32, u32, unsigned int)
+DEFINE_IMM(u8,  unsigned char)
+DEFINE_POP(u8,  unsigned char)
+DEFINE_IMM(u16, unsigned short)
+DEFINE_POP(u16, unsigned short)
+DEFINE_IMM(u32, unsigned int)
+DEFINE_POP(u32, unsigned int)
 
-DEFINE_ARITH(i8,  i8)
-DEFINE_ARITH(i16, i16)
-DEFINE_ARITH(i32, i32)
+DEFINE_ARITH(i8)
+DEFINE_ARITH(i16)
+DEFINE_ARITH(i32)
 
-DEFINE_BITWISE(i8,  i8)
-DEFINE_BITWISE(i16, i16)
-DEFINE_BITWISE(i32, i32)
+DEFINE_BITWISE(i8)
+DEFINE_BITWISE(i16)
+DEFINE_BITWISE(i32)

--- a/vorth.c
+++ b/vorth.c
@@ -1,132 +1,132 @@
 #include "vorth.h"
 
-typedef _Float16 F16 __attribute__((vector_size(sizeof(_Float16) * V)));
-typedef float    F32 __attribute__((vector_size(sizeof(float) * V)));
+typedef _Float16 f16 __attribute__((vector_size(V * sizeof(_Float16))));
+typedef float    f32 __attribute__((vector_size(V * sizeof(float))));
 
-typedef signed char       S8  __attribute__((vector_size(sizeof(signed char) * V)));
-typedef unsigned char     U8  __attribute__((vector_size(sizeof(unsigned char) * V)));
-typedef short             S16 __attribute__((vector_size(sizeof(short) * V)));
-typedef unsigned short    U16 __attribute__((vector_size(sizeof(unsigned short) * V)));
-typedef int               S32 __attribute__((vector_size(sizeof(int) * V)));
-typedef unsigned int      U32 __attribute__((vector_size(sizeof(unsigned int) * V)));
+typedef signed char       s8  __attribute__((vector_size(V * sizeof(signed char))));
+typedef unsigned char     u8  __attribute__((vector_size(V * sizeof(unsigned char))));
+typedef short             s16 __attribute__((vector_size(V * sizeof(short))));
+typedef unsigned short    u16 __attribute__((vector_size(V * sizeof(unsigned short))));
+typedef int               s32 __attribute__((vector_size(V * sizeof(int))));
+typedef unsigned int      u32 __attribute__((vector_size(V * sizeof(unsigned int))));
 
-typedef U8  I8;
-typedef U16 I16;
-typedef U32 I32;
+typedef u8  i8;
+typedef u16 i16;
+typedef u32 i32;
 
 #define splat(T, x) ((T){0} + 1) * (x)
 
-#define DEFINE_IMM(T, suf, ctype)                 \
-    void* vorth_imm_##suf(void* sp, ctype x) {    \
-        T* stack = sp;                            \
-        *stack++ = splat(T, x);                   \
-        return stack;                             \
+#define DEFINE_IMM(T, suf, ctype)                  \
+    void* vorth_imm_##suf(void* sp, ctype x) {     \
+        T* stack = sp;                             \
+        *stack++ = splat(T, x);                    \
+        return stack;                              \
     }
 
-#define DEFINE_ARITH(T, suf)                      \
-    void* vorth_add_##suf(void* sp) {             \
-        T* stack = sp;                            \
-        T const b = *--stack, a = *--stack;       \
-        *stack++ = a + b;                         \
-        return stack;                             \
-    }                                             \
-    void* vorth_sub_##suf(void* sp) {             \
-        T* stack = sp;                            \
-        T const b = *--stack, a = *--stack;       \
-        *stack++ = a - b;                         \
-        return stack;                             \
-    }                                             \
-    void* vorth_mul_##suf(void* sp) {             \
-        T* stack = sp;                            \
-        T const b = *--stack, a = *--stack;       \
-        *stack++ = a * b;                         \
-        return stack;                             \
+#define DEFINE_ARITH(T, suf)                       \
+    void* vorth_add_##suf(void* sp) {              \
+        T* stack = sp;                             \
+        const T b = *--stack, a = *--stack;        \
+        *stack++ = a + b;                          \
+        return stack;                              \
+    }                                              \
+    void* vorth_sub_##suf(void* sp) {              \
+        T* stack = sp;                             \
+        const T b = *--stack, a = *--stack;        \
+        *stack++ = a - b;                          \
+        return stack;                              \
+    }                                              \
+    void* vorth_mul_##suf(void* sp) {              \
+        T* stack = sp;                             \
+        const T b = *--stack, a = *--stack;        \
+        *stack++ = a * b;                          \
+        return stack;                              \
     }
 
-#define DEFINE_POP(T, suf, ctype)                 \
-    void* vorth_pop_##suf(void* sp, ctype out[V]) {\
-        T* stack = sp;                            \
-        T x = *--stack;                           \
-        __builtin_memcpy(out, &x, sizeof x);      \
-        return stack;                             \
-    }
-
-
-#define DEFINE_BITWISE(T, suf)                    \
-    void* vorth_and_##suf(void* sp) {             \
-        T* stack = sp;                            \
-        T const b = *--stack, a = *--stack;       \
-        *stack++ = a & b;                         \
-        return stack;                             \
-    }                                             \
-    void* vorth_or_##suf(void* sp) {              \
-        T* stack = sp;                            \
-        T const b = *--stack, a = *--stack;       \
-        *stack++ = a | b;                         \
-        return stack;                             \
-    }                                             \
-    void* vorth_xor_##suf(void* sp) {             \
-        T* stack = sp;                            \
-        T const b = *--stack, a = *--stack;       \
-        *stack++ = a ^ b;                         \
-        return stack;                             \
-    }                                             \
-    void* vorth_not_##suf(void* sp) {             \
-        T* stack = sp;                            \
-        T const a = *--stack;                     \
-        *stack++ = ~a;                            \
-        return stack;                             \
+#define DEFINE_POP(T, suf, ctype)                  \
+    void* vorth_pop_##suf(void* sp, ctype out[V]) { \
+        T* stack = sp;                             \
+        const T x = *--stack;                      \
+        __builtin_memcpy(out, &x, sizeof x);       \
+        return stack;                              \
     }
 
 
-#define DEFINE_DIV(T, suf)                        \
-    void* vorth_div_##suf(void* sp) {            \
-        T* stack = sp;                           \
-        T const b = *--stack, a = *--stack;      \
-        *stack++ = a / b;                        \
-        return stack;                            \
+#define DEFINE_BITWISE(T, suf)                      \
+    void* vorth_and_##suf(void* sp) {               \
+        T* stack = sp;                              \
+        const T b = *--stack, a = *--stack;         \
+        *stack++ = a & b;                           \
+        return stack;                               \
+    }                                               \
+    void* vorth_or_##suf(void* sp) {                \
+        T* stack = sp;                              \
+        const T b = *--stack, a = *--stack;         \
+        *stack++ = a | b;                           \
+        return stack;                               \
+    }                                               \
+    void* vorth_xor_##suf(void* sp) {               \
+        T* stack = sp;                              \
+        const T b = *--stack, a = *--stack;         \
+        *stack++ = a ^ b;                           \
+        return stack;                               \
+    }                                               \
+    void* vorth_not_##suf(void* sp) {               \
+        T* stack = sp;                              \
+        const T a = *--stack;                       \
+        *stack++ = ~a;                              \
+        return stack;                               \
     }
 
-#define DEFINE_MAD(T, suf)                        \
-    void* vorth_mad_##suf(void* sp) {            \
-        T* stack = sp;                           \
-        T const c = *--stack,                   \
-                  b = *--stack,                 \
-                  a = *--stack;                 \
-        *stack++ = a * b + c;                   \
-        return stack;                           \
+
+#define DEFINE_DIV(T, suf)                          \
+    void* vorth_div_##suf(void* sp) {              \
+        T* stack = sp;                             \
+        const T b = *--stack, a = *--stack;        \
+        *stack++ = a / b;                          \
+        return stack;                              \
     }
 
-DEFINE_IMM(F16, f16, _Float16)
-DEFINE_POP(F16, f16, _Float16)
-DEFINE_ARITH(F16, f16)
-DEFINE_DIV(F16, f16)
-DEFINE_MAD(F16, f16)
+#define DEFINE_MAD(T, suf)                          \
+    void* vorth_mad_##suf(void* sp) {              \
+        T* stack = sp;                             \
+        const T c = *--stack,                      \
+                  b = *--stack,                    \
+                  a = *--stack;                    \
+        *stack++ = a * b + c;                      \
+        return stack;                              \
+    }
 
-DEFINE_IMM(F32, f32, float)
-DEFINE_POP(F32, f32, float)
-DEFINE_ARITH(F32, f32)
-DEFINE_DIV(F32, f32)
-DEFINE_MAD(F32, f32)
+DEFINE_IMM(f16, f16, _Float16)
+DEFINE_POP(f16, f16, _Float16)
+DEFINE_ARITH(f16, f16)
+DEFINE_DIV(f16, f16)
+DEFINE_MAD(f16, f16)
 
-DEFINE_IMM(S8,  s8,  signed char)
-DEFINE_POP(S8,  s8,  signed char)
-DEFINE_IMM(S16, s16, short)
-DEFINE_POP(S16, s16, short)
-DEFINE_IMM(S32, s32, int)
-DEFINE_POP(S32, s32, int)
+DEFINE_IMM(f32, f32, float)
+DEFINE_POP(f32, f32, float)
+DEFINE_ARITH(f32, f32)
+DEFINE_DIV(f32, f32)
+DEFINE_MAD(f32, f32)
 
-DEFINE_IMM(U8,  u8,  unsigned char)
-DEFINE_POP(U8,  u8,  unsigned char)
-DEFINE_IMM(U16, u16, unsigned short)
-DEFINE_POP(U16, u16, unsigned short)
-DEFINE_IMM(U32, u32, unsigned int)
-DEFINE_POP(U32, u32, unsigned int)
+DEFINE_IMM(s8,  s8,  signed char)
+DEFINE_POP(s8,  s8,  signed char)
+DEFINE_IMM(s16, s16, short)
+DEFINE_POP(s16, s16, short)
+DEFINE_IMM(s32, s32, int)
+DEFINE_POP(s32, s32, int)
 
-DEFINE_ARITH(I8,  i8)
-DEFINE_ARITH(I16, i16)
-DEFINE_ARITH(I32, i32)
+DEFINE_IMM(u8,  u8,  unsigned char)
+DEFINE_POP(u8,  u8,  unsigned char)
+DEFINE_IMM(u16, u16, unsigned short)
+DEFINE_POP(u16, u16, unsigned short)
+DEFINE_IMM(u32, u32, unsigned int)
+DEFINE_POP(u32, u32, unsigned int)
 
-DEFINE_BITWISE(I8,  i8)
-DEFINE_BITWISE(I16, i16)
-DEFINE_BITWISE(I32, i32)
+DEFINE_ARITH(i8,  i8)
+DEFINE_ARITH(i16, i16)
+DEFINE_ARITH(i32, i32)
+
+DEFINE_BITWISE(i8,  i8)
+DEFINE_BITWISE(i16, i16)
+DEFINE_BITWISE(i32, i32)

--- a/vorth.c
+++ b/vorth.c
@@ -26,19 +26,19 @@ typedef u32 i32;
 #define DEFINE_ARITH(T, suf)                       \
     void* vorth_add_##suf(void* sp) {              \
         T* stack = sp;                             \
-        const T b = *--stack, a = *--stack;        \
+        T const b = *--stack, a = *--stack;        \
         *stack++ = a + b;                          \
         return stack;                              \
     }                                              \
     void* vorth_sub_##suf(void* sp) {              \
         T* stack = sp;                             \
-        const T b = *--stack, a = *--stack;        \
+        T const b = *--stack, a = *--stack;        \
         *stack++ = a - b;                          \
         return stack;                              \
     }                                              \
     void* vorth_mul_##suf(void* sp) {              \
         T* stack = sp;                             \
-        const T b = *--stack, a = *--stack;        \
+        T const b = *--stack, a = *--stack;        \
         *stack++ = a * b;                          \
         return stack;                              \
     }
@@ -46,7 +46,7 @@ typedef u32 i32;
 #define DEFINE_POP(T, suf, ctype)                  \
     void* vorth_pop_##suf(void* sp, ctype out[V]) { \
         T* stack = sp;                             \
-        const T x = *--stack;                      \
+        T const x = *--stack;                      \
         __builtin_memcpy(out, &x, sizeof x);       \
         return stack;                              \
     }
@@ -55,25 +55,25 @@ typedef u32 i32;
 #define DEFINE_BITWISE(T, suf)                      \
     void* vorth_and_##suf(void* sp) {               \
         T* stack = sp;                              \
-        const T b = *--stack, a = *--stack;         \
+        T const b = *--stack, a = *--stack;         \
         *stack++ = a & b;                           \
         return stack;                               \
     }                                               \
     void* vorth_or_##suf(void* sp) {                \
         T* stack = sp;                              \
-        const T b = *--stack, a = *--stack;         \
+        T const b = *--stack, a = *--stack;         \
         *stack++ = a | b;                           \
         return stack;                               \
     }                                               \
     void* vorth_xor_##suf(void* sp) {               \
         T* stack = sp;                              \
-        const T b = *--stack, a = *--stack;         \
+        T const b = *--stack, a = *--stack;         \
         *stack++ = a ^ b;                           \
         return stack;                               \
     }                                               \
     void* vorth_not_##suf(void* sp) {               \
         T* stack = sp;                              \
-        const T a = *--stack;                       \
+        T const a = *--stack;                       \
         *stack++ = ~a;                              \
         return stack;                               \
     }
@@ -82,7 +82,7 @@ typedef u32 i32;
 #define DEFINE_DIV(T, suf)                          \
     void* vorth_div_##suf(void* sp) {              \
         T* stack = sp;                             \
-        const T b = *--stack, a = *--stack;        \
+        T const b = *--stack, a = *--stack;        \
         *stack++ = a / b;                          \
         return stack;                              \
     }
@@ -90,9 +90,9 @@ typedef u32 i32;
 #define DEFINE_MAD(T, suf)                          \
     void* vorth_mad_##suf(void* sp) {              \
         T* stack = sp;                             \
-        const T c = *--stack,                      \
-                  b = *--stack,                    \
-                  a = *--stack;                    \
+        T const c = *--stack,                      \
+                b = *--stack,                      \
+                a = *--stack;                      \
         *stack++ = a * b + c;                      \
         return stack;                              \
     }


### PR DESCRIPTION
## Summary
- rename vector types to lowercase for consistent macro use
- use `const` qualifiers for popped values
- ensure trailing `\` characters line up in macros
- use `vector_size(V * sizeof(...))` for clarity

## Testing
- `ninja -f build.ninja`

------
https://chatgpt.com/codex/tasks/task_e_68576b9a7f4c8326b5a6f92afa1931be