### PR TITLE
Add masked load/store operations

### DIFF
--- a/vorth.c
+++ b/vorth.c
@@ -51,6 +51,40 @@ typedef u32 i32;
         return stack;                              \
     }
 
+#define DEFINE_LOAD(T, ctype)                        \
+    void* vorth_load_##T(void* sp, const ctype* src) {\
+        T* stack = sp;                              \
+        T x;                                        \
+        __builtin_memcpy(&x, src, sizeof x);        \
+        *stack++ = x;                               \
+        return stack;                               \
+    }
+
+#define DEFINE_LOAD_MASK(T, ctype)                                   \
+    void* vorth_load_mask_##T(void* sp, const ctype* src, vorth_mask mask) {\
+        T* stack = sp;                                               \
+        ctype tmp[V] = {0};                                          \
+        for (int i = 0; i < V; i++)                                  \
+            if (mask & (1u << i))                                     \
+                tmp[i] = src[i];                                     \
+        T x;                                                         \
+        __builtin_memcpy(&x, tmp, sizeof x);                         \
+        *stack++ = x;                                                \
+        return stack;                                                \
+    }
+
+#define DEFINE_STORE_MASK(T, ctype)                               \
+    void* vorth_store_mask_##T(void* sp, ctype* dst, vorth_mask mask) {\
+        T* stack = sp;                                              \
+        T const x = *--stack;                                       \
+        ctype tmp[V];                                               \
+        __builtin_memcpy(tmp, &x, sizeof x);                        \
+        for (int i = 0; i < V; i++)                                 \
+            if (mask & (1u << i))                                   \
+                dst[i] = tmp[i];                                    \
+        return stack;                                               \
+    }
+
 
 #define DEFINE_BITWISE(T)                           \
     void* vorth_and_##T(void* sp) {                 \
@@ -99,29 +133,53 @@ typedef u32 i32;
 
 DEFINE_IMM(f16, _Float16)
 DEFINE_POP(f16, _Float16)
+DEFINE_LOAD(f16, _Float16)
+DEFINE_LOAD_MASK(f16, _Float16)
+DEFINE_STORE_MASK(f16, _Float16)
 DEFINE_ARITH(f16)
 DEFINE_DIV(f16)
 DEFINE_MAD(f16)
 
 DEFINE_IMM(f32, float)
 DEFINE_POP(f32, float)
+DEFINE_LOAD(f32, float)
+DEFINE_LOAD_MASK(f32, float)
+DEFINE_STORE_MASK(f32, float)
 DEFINE_ARITH(f32)
 DEFINE_DIV(f32)
 DEFINE_MAD(f32)
 
 DEFINE_IMM(s8,  signed char)
 DEFINE_POP(s8,  signed char)
+DEFINE_LOAD(s8, signed char)
+DEFINE_LOAD_MASK(s8, signed char)
+DEFINE_STORE_MASK(s8, signed char)
 DEFINE_IMM(s16, short)
 DEFINE_POP(s16, short)
+DEFINE_LOAD(s16, short)
+DEFINE_LOAD_MASK(s16, short)
+DEFINE_STORE_MASK(s16, short)
 DEFINE_IMM(s32, int)
 DEFINE_POP(s32, int)
+DEFINE_LOAD(s32, int)
+DEFINE_LOAD_MASK(s32, int)
+DEFINE_STORE_MASK(s32, int)
 
 DEFINE_IMM(u8,  unsigned char)
 DEFINE_POP(u8,  unsigned char)
+DEFINE_LOAD(u8, unsigned char)
+DEFINE_LOAD_MASK(u8, unsigned char)
+DEFINE_STORE_MASK(u8, unsigned char)
 DEFINE_IMM(u16, unsigned short)
 DEFINE_POP(u16, unsigned short)
+DEFINE_LOAD(u16, unsigned short)
+DEFINE_LOAD_MASK(u16, unsigned short)
+DEFINE_STORE_MASK(u16, unsigned short)
 DEFINE_IMM(u32, unsigned int)
 DEFINE_POP(u32, unsigned int)
+DEFINE_LOAD(u32, unsigned int)
+DEFINE_LOAD_MASK(u32, unsigned int)
+DEFINE_STORE_MASK(u32, unsigned int)
 
 DEFINE_ARITH(i8)
 DEFINE_ARITH(i16)

--- a/vorth.h
+++ b/vorth.h
@@ -2,6 +2,8 @@
 
 #define V 8
 
+typedef unsigned vorth_mask;
+
 void* vorth_imm_f16(void*, _Float16);
 void* vorth_add_f16(void*);
 void* vorth_sub_f16(void*);
@@ -18,24 +20,48 @@ void* vorth_mad_f32(void*);
 
 void* vorth_pop_f16(void*, _Float16[V]);
 void* vorth_pop_f32(void*, float[V]);
+void* vorth_load_f16(void*, const _Float16*);
+void* vorth_load_f32(void*, const float*);
+void* vorth_load_mask_f16(void*, const _Float16*, vorth_mask);
+void* vorth_load_mask_f32(void*, const float*, vorth_mask);
+void* vorth_store_mask_f16(void*, _Float16*, vorth_mask);
+void* vorth_store_mask_f32(void*, float*, vorth_mask);
 
 void* vorth_imm_s8(void*, signed char);
 void* vorth_pop_s8(void*, signed char[V]);
+void* vorth_load_s8(void*, const signed char*);
+void* vorth_load_mask_s8(void*, const signed char*, vorth_mask);
+void* vorth_store_mask_s8(void*, signed char*, vorth_mask);
 
 void* vorth_imm_s16(void*, short);
 void* vorth_pop_s16(void*, short[V]);
+void* vorth_load_s16(void*, const short*);
+void* vorth_load_mask_s16(void*, const short*, vorth_mask);
+void* vorth_store_mask_s16(void*, short*, vorth_mask);
 
 void* vorth_imm_s32(void*, int);
 void* vorth_pop_s32(void*, int[V]);
+void* vorth_load_s32(void*, const int*);
+void* vorth_load_mask_s32(void*, const int*, vorth_mask);
+void* vorth_store_mask_s32(void*, int*, vorth_mask);
 
 void* vorth_imm_u8(void*, unsigned char);
 void* vorth_pop_u8(void*, unsigned char[V]);
+void* vorth_load_u8(void*, const unsigned char*);
+void* vorth_load_mask_u8(void*, const unsigned char*, vorth_mask);
+void* vorth_store_mask_u8(void*, unsigned char*, vorth_mask);
 
 void* vorth_imm_u16(void*, unsigned short);
 void* vorth_pop_u16(void*, unsigned short[V]);
+void* vorth_load_u16(void*, const unsigned short*);
+void* vorth_load_mask_u16(void*, const unsigned short*, vorth_mask);
+void* vorth_store_mask_u16(void*, unsigned short*, vorth_mask);
 
 void* vorth_imm_u32(void*, unsigned int);
 void* vorth_pop_u32(void*, unsigned int[V]);
+void* vorth_load_u32(void*, const unsigned int*);
+void* vorth_load_mask_u32(void*, const unsigned int*, vorth_mask);
+void* vorth_store_mask_u32(void*, unsigned int*, vorth_mask);
 
 void* vorth_add_i8(void*);
 void* vorth_sub_i8(void*);

--- a/vorth_test.c
+++ b/vorth_test.c
@@ -172,11 +172,35 @@ static void test_f32(void) {
     }
 }
 
+static void test_mask(void) {
+    int stack[8 * V] __attribute__((aligned(sizeof(int) * V)));
+    void* sp = stack;
+
+    int src[V];
+    for (int i = 0; i < V; i++)
+        src[i] = i + 1;
+
+    sp = vorth_load_s32(sp, src);
+    int dst[V] = {0};
+    sp = vorth_store_mask_s32(sp, dst, (1u << V) - 1);
+    for (int i = 0; i < V; i++)
+        assert(dst[i] == src[i]);
+
+    sp = vorth_load_mask_s32(sp, src, (1u << (V - 1)) - 1);
+    int dst2[V] = {0};
+    sp = vorth_store_mask_s32(sp, dst2, (1u << (V - 1)) - 1);
+    for (int i = 0; i < V - 1; i++)
+        assert(dst2[i] == src[i]);
+    for (int i = V - 1; i < V; i++)
+        assert(dst2[i] == 0);
+}
+
 int main(void) {
     test_i8();
     test_i16();
     test_i32();
     test_f16();
     test_f32();
+    test_mask();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `vorth_mask` type and prototypes for masked memory operations
- implement load and masked load/store helpers for all data types
- exercise new functions in unit tests

## Testing
- `ninja -f build.ninja -j1`

------
https://chatgpt.com/codex/tasks/task_e_685770b7c73c83269273be2fadd115f4